### PR TITLE
feat(style): add clang-format, clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ build/
 
 # Cache
 .cache
+
+# Clang
+.clang-format
+.clang-tidy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,29 +1,29 @@
 #include "spdlog/spdlog.h"
 #include <fmt/base.h>
 
-int main() {
+int main()
+{
+    fmt::print("Hello, world!\n");
 
-  fmt::print("Hello, world!\n");
+    spdlog::info("Welcome to spdlog!");
+    spdlog::error("Some error message with arg: {}", 1);
 
-  spdlog::info("Welcome to spdlog!");
-  spdlog::error("Some error message with arg: {}", 1);
+    spdlog::warn("Easy padding in numbers like {:08d}", 12);
+    spdlog::critical(
+        "Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
+    spdlog::info("Support for floats {:03.2f}", 1.23456);
+    spdlog::info("Positional args are {1} {0}..", "too", "supported");
+    spdlog::info("{:<30}", "left aligned");
 
-  spdlog::warn("Easy padding in numbers like {:08d}", 12);
-  spdlog::critical(
-      "Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
-  spdlog::info("Support for floats {:03.2f}", 1.23456);
-  spdlog::info("Positional args are {1} {0}..", "too", "supported");
-  spdlog::info("{:<30}", "left aligned");
+    spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+    spdlog::debug("This message should be displayed..");
 
-  spdlog::set_level(spdlog::level::debug); // Set global log level to debug
-  spdlog::debug("This message should be displayed..");
+    // change log pattern
+    spdlog::set_pattern("[%H:%M:%S %z] [%n] [%^---%L---%$] [thread %t] %v");
 
-  // change log pattern
-  spdlog::set_pattern("[%H:%M:%S %z] [%n] [%^---%L---%$] [thread %t] %v");
-
-  // Compile time log levels
-  // Note that this does not change the current log level, it will only
-  // remove (depending on SPDLOG_ACTIVE_LEVEL) the call on the release code.
-  SPDLOG_TRACE("Some trace message with param {}", 42);
-  SPDLOG_DEBUG("Some debug message");
+    // Compile time log levels
+    // Note that this does not change the current log level, it will only
+    // remove (depending on SPDLOG_ACTIVE_LEVEL) the call on the release code.
+    SPDLOG_TRACE("Some trace message with param {}", 42);
+    SPDLOG_DEBUG("Some debug message");
 }


### PR DESCRIPTION
## What's Included
- Added .clang-format file with standardized C++ formatting rules
- Added .clang-tidy file with static analysis checks